### PR TITLE
[Expo] Location.geocodeAsync should return an array

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2126,7 +2126,7 @@ export namespace Location {
     function getProviderStatusAsync(): Promise<ProviderStatus>;
     function getHeadingAsync(): Promise<HeadingStatus>;
     function watchHeadingAsync(callback: (status: HeadingStatus) => void): EventSubscription;
-    function geocodeAsync(address: string): Promise<Coords>;
+    function geocodeAsync(address: string): Promise<Coords[]>;
     function reverseGeocodeAsync(location: LocationProps): Promise<GeocodeData[]>;
     function setApiKey(key: string): void;
 }


### PR DESCRIPTION
According to the docs, this method returns an array of Coords: https://docs.expo.io/versions/v31.0.0/sdk/location.

Please fill in this template.

- [ Expo] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.expo.io/versions/v31.0.0/sdk/location>
